### PR TITLE
add-night-mode-functionality implementing  esphome sps30 idle mode

### DIFF
--- a/ultimatesensor-v1/.gitignore
+++ b/ultimatesensor-v1/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.2"
+  ultimatesensor_software_version: "1.3"
   ultimatesensor_hardware_version: "V1-Basic"
   ultimatesensor_connection_type: "Ethernet"
 

--- a/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.3"
+  ultimatesensor_software_version: "1.4"
   ultimatesensor_hardware_version: "V1-Basic"
   ultimatesensor_connection_type: "Ethernet"
 

--- a/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-basic.yaml
@@ -87,6 +87,7 @@ display:
   - platform: ssd1306_i2c
     model: "SSD1306 128x64"
     address: 0x3C
+    id: oled_display
     contrast: 40%
     lambda: |-
       // Display the CO2 measurement
@@ -842,6 +843,20 @@ number:
 button:
   - platform: restart
     name: "Restart UltimateSensor"
+
+switch:
+  - platform: template
+    name: "LCD Display"
+    id: lcd_display_switch
+    icon: "mdi:monitor"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    turn_on_action:
+      - lambda: |-
+          id(oled_display).turn_on();
+    turn_off_action:
+      - lambda: |-
+          id(oled_display).turn_off();
 
 text_sensor:
   # ESPHome information

--- a/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
@@ -20,6 +20,15 @@ esphome:
   project:
     name: "smarthomeshop.ultimatesensor"
     version: ${ultimatesensor_software_version}
+  on_boot:
+    priority: -100  # Run after all components are initialized
+    then:
+      - delay: 5s  # Wait for sensor to initialize
+      - if:
+          condition:
+            lambda: 'return !id(pm_sensor_enabled);'
+          then:
+            - sps30.stop_measurement: pm_sensor
 
 esp32:
   board: esp32dev
@@ -908,14 +917,12 @@ switch:
       - globals.set:
           id: pm_sensor_enabled
           value: 'true'
-      - lambda: |-
-          id(pm_sensor).set_update_interval(120000);
+      - sps30.start_measurement: pm_sensor
     turn_off_action:
       - globals.set:
           id: pm_sensor_enabled
           value: 'false'
-      - lambda: |-
-          id(pm_sensor).set_update_interval(4294967295);
+      - sps30.stop_measurement: pm_sensor
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
@@ -20,15 +20,6 @@ esphome:
   project:
     name: "smarthomeshop.ultimatesensor"
     version: ${ultimatesensor_software_version}
-  on_boot:
-    priority: -100  # Run after all components are initialized
-    then:
-      - delay: 5s  # Wait for sensor to initialize
-      - if:
-          condition:
-            lambda: 'return !id(pm_sensor_enabled);'
-          then:
-            - sps30.stop_measurement: pm_sensor
 
 esp32:
   board: esp32dev
@@ -917,12 +908,18 @@ switch:
       - globals.set:
           id: pm_sensor_enabled
           value: 'true'
-      - sps30.start_measurement: pm_sensor
+      - lambda: |-
+          // Send I2C command to start continuous measurement (0x0010 with arg 0x0300)
+          uint8_t start_cmd[] = {0x00, 0x10, 0x03, 0x00, 0xAC};
+          id(bus_a).write(0x69, start_cmd, 5);
     turn_off_action:
       - globals.set:
           id: pm_sensor_enabled
           value: 'false'
-      - sps30.stop_measurement: pm_sensor
+      - lambda: |-
+          // Send I2C command to stop measurement (0x0104)
+          uint8_t stop_cmd[] = {0x01, 0x04};
+          id(bus_a).write(0x69, stop_cmd, 2);
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.2"
+  ultimatesensor_software_version: "1.3"
   ultimatesensor_hardware_version: "V1-Complete"
   ultimatesensor_connection_type: "Ethernet"
 

--- a/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
@@ -87,6 +87,7 @@ display:
   - platform: ssd1306_i2c
     model: "SSD1306 128x64"
     address: 0x3C
+    id: oled_display
     contrast: 40%
     lambda: |-
       // Display the CO2 measurement
@@ -147,6 +148,7 @@ sensor:
 
   # SPS30 (For complete version)
   - platform: sps30
+    id: pm_sensor
     pm_1_0:
       name: "PM <1µm Weight concentration"
       id: "workshop_PM_1_0"
@@ -329,6 +331,10 @@ globals:
     type: unsigned long
     restore_value: no
     initial_value: '0'
+  - id: pm_sensor_enabled
+    type: bool
+    restore_value: yes
+    initial_value: 'true'
 
 
 uart:
@@ -877,6 +883,51 @@ number:
 button:
   - platform: restart
     name: "Restart UltimateSensor"
+
+switch:
+  - platform: template
+    name: "LCD Display"
+    id: lcd_display_switch
+    icon: "mdi:monitor"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    turn_on_action:
+      - lambda: |-
+          id(oled_display).turn_on();
+    turn_off_action:
+      - lambda: |-
+          id(oled_display).turn_off();
+  - platform: template
+    name: "PM Sensor"
+    id: pm_sensor_switch
+    icon: "mdi:air-filter"
+    restore_mode: RESTORE_DEFAULT_ON
+    lambda: |-
+      return id(pm_sensor_enabled);
+    turn_on_action:
+      - globals.set:
+          id: pm_sensor_enabled
+          value: 'true'
+      - lambda: |-
+          id(pm_sensor).set_update_interval(120000);
+    turn_off_action:
+      - globals.set:
+          id: pm_sensor_enabled
+          value: 'false'
+      - lambda: |-
+          id(pm_sensor).set_update_interval(4294967295);
+  - platform: template
+    name: "Night Mode"
+    id: night_mode_switch
+    icon: "mdi:weather-night"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    turn_on_action:
+      - switch.turn_off: lcd_display_switch
+      - switch.turn_off: pm_sensor_switch
+    turn_off_action:
+      - switch.turn_on: lcd_display_switch
+      - switch.turn_on: pm_sensor_switch
 
 text_sensor:
   # ESPHome information

--- a/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-ethernet-complete.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.3"
+  ultimatesensor_software_version: "1.4"
   ultimatesensor_hardware_version: "V1-Complete"
   ultimatesensor_connection_type: "Ethernet"
 
@@ -331,10 +331,6 @@ globals:
     type: unsigned long
     restore_value: no
     initial_value: '0'
-  - id: pm_sensor_enabled
-    type: bool
-    restore_value: yes
-    initial_value: 'true'
 
 
 uart:
@@ -902,24 +898,11 @@ switch:
     id: pm_sensor_switch
     icon: "mdi:air-filter"
     restore_mode: RESTORE_DEFAULT_ON
-    lambda: |-
-      return id(pm_sensor_enabled);
+    optimistic: true
     turn_on_action:
-      - globals.set:
-          id: pm_sensor_enabled
-          value: 'true'
-      - lambda: |-
-          // Send I2C command to start continuous measurement (0x0010 with arg 0x0300)
-          uint8_t start_cmd[] = {0x00, 0x10, 0x03, 0x00, 0xAC};
-          id(bus_a).write(0x69, start_cmd, 5);
+      - sps30.start_measurement: pm_sensor
     turn_off_action:
-      - globals.set:
-          id: pm_sensor_enabled
-          value: 'false'
-      - lambda: |-
-          // Send I2C command to stop measurement (0x0104)
-          uint8_t stop_cmd[] = {0x01, 0x04};
-          id(bus_a).write(0x69, stop_cmd, 2);
+      - sps30.stop_measurement: pm_sensor
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
@@ -90,6 +90,7 @@ display:
   - platform: ssd1306_i2c
     model: "SSD1306 128x64"
     address: 0x3C
+    id: oled_display
     contrast: 40%
     lambda: |-
       // Display the CO2 measurement
@@ -845,6 +846,20 @@ number:
 button:
   - platform: restart
     name: "Restart UltimateSensor"
+
+switch:
+  - platform: template
+    name: "LCD Display"
+    id: lcd_display_switch
+    icon: "mdi:monitor"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    turn_on_action:
+      - lambda: |-
+          id(oled_display).turn_on();
+    turn_off_action:
+      - lambda: |-
+          id(oled_display).turn_off();
 
 text_sensor:
   # WiFi info

--- a/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.2"
+  ultimatesensor_software_version: "1.3"
   ultimatesensor_hardware_version: "V1-Basic"
   ultimatesensor_connection_type: "WiFi"
 

--- a/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-basic.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.3"
+  ultimatesensor_software_version: "1.4"
   ultimatesensor_hardware_version: "V1-Basic"
   ultimatesensor_connection_type: "WiFi"
 

--- a/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.2"
+  ultimatesensor_software_version: "1.3"
   ultimatesensor_hardware_version: "V1-Complete"
   ultimatesensor_connection_type: "WiFi"
 

--- a/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
@@ -7,7 +7,7 @@
 substitutions:
   device_name: ultimatesensor
   friendly_name: "UltimateSensor"
-  ultimatesensor_software_version: "1.3"
+  ultimatesensor_software_version: "1.4"
   ultimatesensor_hardware_version: "V1-Complete"
   ultimatesensor_connection_type: "WiFi"
 
@@ -350,10 +350,6 @@ globals:
     type: unsigned long
     restore_value: no
     initial_value: '0'
-  - id: pm_sensor_enabled
-    type: bool
-    restore_value: yes
-    initial_value: 'true'
 
 
 uart:
@@ -929,24 +925,11 @@ switch:
     id: pm_sensor_switch
     icon: "mdi:air-filter"
     restore_mode: RESTORE_DEFAULT_ON
-    lambda: |-
-      return id(pm_sensor_enabled);
+    optimistic: true
     turn_on_action:
-      - globals.set:
-          id: pm_sensor_enabled
-          value: 'true'
-      - lambda: |-
-          // Send I2C command to start continuous measurement (0x0010 with arg 0x0300)
-          uint8_t start_cmd[] = {0x00, 0x10, 0x03, 0x00, 0xAC};
-          id(bus_a).write(0x69, start_cmd, 5);
+      - sps30.start_measurement: pm_sensor
     turn_off_action:
-      - globals.set:
-          id: pm_sensor_enabled
-          value: 'false'
-      - lambda: |-
-          // Send I2C command to stop measurement (0x0104)
-          uint8_t stop_cmd[] = {0x01, 0x04};
-          id(bus_a).write(0x69, stop_cmd, 2);
+      - sps30.stop_measurement: pm_sensor
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
@@ -20,6 +20,15 @@ esphome:
   project:
     name: "smarthomeshop.ultimatesensor"
     version: ${ultimatesensor_software_version}
+  on_boot:
+    priority: -100  # Run after all components are initialized
+    then:
+      - delay: 5s  # Wait for sensor to initialize
+      - if:
+          condition:
+            lambda: 'return !id(pm_sensor_enabled);'
+          then:
+            - sps30.stop_measurement: pm_sensor
 
 esp32:
   board: esp32dev
@@ -935,14 +944,12 @@ switch:
       - globals.set:
           id: pm_sensor_enabled
           value: 'true'
-      - lambda: |-
-          id(pm_sensor).set_update_interval(120000);
+      - sps30.start_measurement: pm_sensor
     turn_off_action:
       - globals.set:
           id: pm_sensor_enabled
           value: 'false'
-      - lambda: |-
-          id(pm_sensor).set_update_interval(4294967295);
+      - sps30.stop_measurement: pm_sensor
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
@@ -20,15 +20,6 @@ esphome:
   project:
     name: "smarthomeshop.ultimatesensor"
     version: ${ultimatesensor_software_version}
-  on_boot:
-    priority: -100  # Run after all components are initialized
-    then:
-      - delay: 5s  # Wait for sensor to initialize
-      - if:
-          condition:
-            lambda: 'return !id(pm_sensor_enabled);'
-          then:
-            - sps30.stop_measurement: pm_sensor
 
 esp32:
   board: esp32dev
@@ -944,12 +935,18 @@ switch:
       - globals.set:
           id: pm_sensor_enabled
           value: 'true'
-      - sps30.start_measurement: pm_sensor
+      - lambda: |-
+          // Send I2C command to start continuous measurement (0x0010 with arg 0x0300)
+          uint8_t start_cmd[] = {0x00, 0x10, 0x03, 0x00, 0xAC};
+          id(bus_a).write(0x69, start_cmd, 5);
     turn_off_action:
       - globals.set:
           id: pm_sensor_enabled
           value: 'false'
-      - sps30.stop_measurement: pm_sensor
+      - lambda: |-
+          // Send I2C command to stop measurement (0x0104)
+          uint8_t stop_cmd[] = {0x01, 0x04};
+          id(bus_a).write(0x69, stop_cmd, 2);
   - platform: template
     name: "Night Mode"
     id: night_mode_switch

--- a/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
+++ b/ultimatesensor-v1/ultimatesensor-wifi-complete.yaml
@@ -105,6 +105,7 @@ display:
   - platform: ssd1306_i2c
     model: "SSD1306 128x64"
     address: 0x3C
+    id: oled_display
     contrast: 40%
     lambda: |-
       // Display the CO2 measurement
@@ -166,6 +167,7 @@ sensor:
 
   # SPS30 (For complete version)
   - platform: sps30
+    id: pm_sensor
     pm_1_0:
       name: "PM <1µm Weight concentration"
       id: "workshop_PM_1_0"
@@ -348,6 +350,10 @@ globals:
     type: unsigned long
     restore_value: no
     initial_value: '0'
+  - id: pm_sensor_enabled
+    type: bool
+    restore_value: yes
+    initial_value: 'true'
 
 
 uart:
@@ -904,6 +910,51 @@ button:
       - scd4x.perform_forced_calibration:
           value: 419
           id: scd41
+
+switch:
+  - platform: template
+    name: "LCD Display"
+    id: lcd_display_switch
+    icon: "mdi:monitor"
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    turn_on_action:
+      - lambda: |-
+          id(oled_display).turn_on();
+    turn_off_action:
+      - lambda: |-
+          id(oled_display).turn_off();
+  - platform: template
+    name: "PM Sensor"
+    id: pm_sensor_switch
+    icon: "mdi:air-filter"
+    restore_mode: RESTORE_DEFAULT_ON
+    lambda: |-
+      return id(pm_sensor_enabled);
+    turn_on_action:
+      - globals.set:
+          id: pm_sensor_enabled
+          value: 'true'
+      - lambda: |-
+          id(pm_sensor).set_update_interval(120000);
+    turn_off_action:
+      - globals.set:
+          id: pm_sensor_enabled
+          value: 'false'
+      - lambda: |-
+          id(pm_sensor).set_update_interval(4294967295);
+  - platform: template
+    name: "Night Mode"
+    id: night_mode_switch
+    icon: "mdi:weather-night"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    turn_on_action:
+      - switch.turn_off: lcd_display_switch
+      - switch.turn_off: pm_sensor_switch
+    turn_off_action:
+      - switch.turn_on: lcd_display_switch
+      - switch.turn_on: pm_sensor_switch
 
 text_sensor:
   # WiFi info


### PR DESCRIPTION
This pull request introduces several enhancements and new features to all `ultimatesensor-v1` ESPHome YAML configurations, including version updates, improved display control, and new switches for sensor and night mode management. Additionally, a `.gitignore` file is added for ESPHome development.

**Configuration and Versioning Updates:**

* Updated the `ultimatesensor_software_version` substitution from "1.2" to "1.4" in all YAML configuration files to reflect the new software version. [[1]](diffhunk://#diff-a3770364b76f54f220ce4aaacea9e29ed3565ed2bf44624610833693d617bda9L10-R10) [[2]](diffhunk://#diff-88da9783ffb25c7106ab4ecb1b9db30e14cabc15050b8b30b08f635b7391bc2dL10-R10) [[3]](diffhunk://#diff-8c709a45ae1fcc1c41cba43ff0ea2a90aa3820fb34e655e332429506c56a2316L10-R10) [[4]](diffhunk://#diff-eee30ec6755c8a53ad71061a470d33e686ca0bda6707cb407cb2c522e455b334L10-R10)
* Added a `.gitignore` file to exclude ESPHome build artifacts and secrets from version control.

**Display Enhancements:**

* Assigned an `id: oled_display` to all `ssd1306_i2c` display components, enabling programmatic control of the OLED display. [[1]](diffhunk://#diff-a3770364b76f54f220ce4aaacea9e29ed3565ed2bf44624610833693d617bda9R90) [[2]](diffhunk://#diff-88da9783ffb25c7106ab4ecb1b9db30e14cabc15050b8b30b08f635b7391bc2dR90) [[3]](diffhunk://#diff-8c709a45ae1fcc1c41cba43ff0ea2a90aa3820fb34e655e332429506c56a2316R93) [[4]](diffhunk://#diff-eee30ec6755c8a53ad71061a470d33e686ca0bda6707cb407cb2c522e455b334R108)
* Added a template switch (`lcd_display_switch`) to toggle the OLED display on and off via Home Assistant or ESPHome dashboard. [[1]](diffhunk://#diff-a3770364b76f54f220ce4aaacea9e29ed3565ed2bf44624610833693d617bda9R847-R860) [[2]](diffhunk://#diff-88da9783ffb25c7106ab4ecb1b9db30e14cabc15050b8b30b08f635b7391bc2dR883-R918) [[3]](diffhunk://#diff-8c709a45ae1fcc1c41cba43ff0ea2a90aa3820fb34e655e332429506c56a2316R850-R863) [[4]](diffhunk://#diff-eee30ec6755c8a53ad71061a470d33e686ca0bda6707cb407cb2c522e455b334R910-R945)

**Sensor and Switch Features (Complete Versions):**

* Added `id: pm_sensor` to the `sps30` PM sensor for easier reference and control. [[1]](diffhunk://#diff-88da9783ffb25c7106ab4ecb1b9db30e14cabc15050b8b30b08f635b7391bc2dR151) [[2]](diffhunk://#diff-eee30ec6755c8a53ad71061a470d33e686ca0bda6707cb407cb2c522e455b334R170)
* Introduced a template switch (`pm_sensor_switch`) to start and stop PM sensor measurements, and a `night_mode_switch` that can simultaneously turn off the display and PM sensor for low-power/night operation. [[1]](diffhunk://#diff-88da9783ffb25c7106ab4ecb1b9db30e14cabc15050b8b30b08f635b7391bc2dR883-R918) [[2]](diffhunk://#diff-eee30ec6755c8a53ad71061a470d33e686ca0bda6707cb407cb2c522e455b334R910-R945)